### PR TITLE
Added Tile:getPosition() method

### DIFF
--- a/lime/lime-tile.lua
+++ b/lime/lime-tile.lua
@@ -300,6 +300,20 @@ function Tile:updateGridPosition()
 	end
 end
 
+--- Gets the position of the Tile.
+-- @return The X position of the Tile or nil if there is no sprite
+-- @return The Y position of the Tile or nil if there is no sprite
+function Tile:getPosition()
+
+	local visual = self:getVisual()
+	
+	if visual then
+		return visual.x, visual.y
+	end
+	
+	return nil
+end
+
 --- Sets the position of the Tile.
 -- @param x The new X position.
 -- @param y The new Y position.


### PR DESCRIPTION
I believe the Lime is missing this method for tiles.
In my case I want to set one tile's position to another tile's position. They are on different layers that have matching positions so this is ok.
I can't use

``` lua
one:setPosition(another:getWorldPosition())
```

because getWorldPosition is affected by map dragging.
With this change I can do what I want:

``` lua
one:setPosition(another:getPosition())
```
