### PR TITLE
Fix inaccuracy in Utils:slideObjectToPosition.

### DIFF
--- a/lime/lime-utils.lua
+++ b/lime/lime-utils.lua
@@ -629,7 +629,8 @@ function Utils:slideObjectToPosition( object, visual, x, y, slideTime, onComplet
 	end
 	
 	local onSlideComplete = function(event)
-	
+		_object.onSlideTransitionUpdate(event);
+		
 		if _onCompleteHandler then
 			_onCompleteHandler(event)
 		end


### PR DESCRIPTION
Sometimes transition stops in a few pixels from the destination position. This patch finalizes position at the transition end.
