### PR TITLE
Update line 18

### DIFF
--- a/lime/lime-tile.lua
+++ b/lime/lime-tile.lua
@@ -15,7 +15,7 @@
 ----									REQUIRED MODULES										----
 ----------------------------------------------------------------------------------------------------
 
-local sprite = require("sprite") -- doh! old sprite stuff needs updated!
+local sprite = require("lime.sprite") -- doh! old sprite stuff needs updated!
 
 ----------------------------------------------------------------------------------------------------
 ----									CLASS METATABLE											----


### PR DESCRIPTION
Corona SDK  team said the sprite library is deprecated.
Then, to don't change all project, just include sprite.lua in lime directory and update line 18 to require "lime.sprite".

Link to the answer:
http://forums.coronalabs.com/topic/42601-requiresprite-error-after-i-updated-version-of-corona/?p=222069
